### PR TITLE
Patch 0.214.2 Fix to stop Log Spam

### DIFF
--- a/TrashItems/TrashItems.cs
+++ b/TrashItems/TrashItems.cs
@@ -399,7 +399,7 @@ namespace TrashItems
 
         private void Update()
         {
-            if (ZInput.GetButtonDown("JoyButtonA") && handler.IsActive())
+            if (ZInput.GetButtonDown("JoyButtonA") && handler.IsActive)
             {
                 TrashItems.TrashItem();
                 // Switch back to inventory iab


### PR DESCRIPTION
Fix for change in patch 0.214.2 where UIGroupHandler.IsActive() changed to UIGroupHandler.IsActive. Mod currently spams errors to log when player inventory open. This change fixes the issue.